### PR TITLE
fix: Use correct Sanity field names for father/mother (fatherName/motherName)

### DIFF
--- a/src/server/api/routers/r-sanity.ts
+++ b/src/server/api/routers/r-sanity.ts
@@ -240,8 +240,8 @@ export const sanityRouter = createTRPCRouter({
         ownerName,
         microchip,
         birthday,
-        father,
-        mother,
+        "father": fatherName,
+        "mother": motherName,
         createdAt,
         updatedAt
       } | order(createdAt desc)`;
@@ -281,8 +281,8 @@ export const sanityRouter = createTRPCRouter({
           ownerTel,
           microchip,
           name,
-          father,
-          mother,
+          "father": fatherName,
+          "mother": motherName,
           birthday,
           createdAt,
           updatedAt
@@ -321,8 +321,8 @@ export const sanityRouter = createTRPCRouter({
           ownerTel,
           microchip,
           name,
-          father,
-          mother,
+          "father": fatherName,
+          "mother": motherName,
           birthday,
           createdAt,
           updatedAt
@@ -398,8 +398,8 @@ export const sanityRouter = createTRPCRouter({
             type,
             level,
             birthday,
-            father,
-            mother,
+            "father": fatherName,
+            "mother": motherName,
             "event": event->{title}
           }`
         );
@@ -534,8 +534,8 @@ export const sanityRouter = createTRPCRouter({
             type,
             level,
             birthday,
-            father,
-            mother,
+            "father": fatherName,
+            "mother": motherName,
             "event": event->{title}
           }`
         );


### PR DESCRIPTION
## 🐛 Bug Fix: Missing Pedigree Information in Excel/DOCX Export

### Problem
When exporting event registration data to XLSX or DOCX format, the **"พ่อ" (Father)** and **"แม่" (Mother)** columns appeared empty, even though this data exists in Sanity CMS.

### Root Cause
**Schema field name mismatch**: The code was querying for `father` and `mother`, but the Sanity CMS schema uses `fatherName` and `motherName`.

### Solution
Updated all 5 Sanity GROQ queries to use field aliases:
```groq
// Before (incorrect)
father,
mother,

// After (correct)
"father": fatherName,
"mother": motherName,
```

### Changes Made

**File**: `src/server/api/routers/r-sanity.ts`

| Query | Function | Lines |
|-------|----------|-------|
| 1 | getAvailableEvents | 243-244 |
| 2 | getEventData | 284-285 |
| 3 | getAllEventRegisters | 324-325 |
| 4 | exportEventData (XLSX) | 401-402 |
| 5 | exportEventDataToDocx (DOCX) | 537-538 |

### Impact
- ✅ **XLSX Export**: Now includes father/mother names in "พ่อ" and "แม่" columns
- ✅ **DOCX Export**: Now includes pedigree info in registration forms
- ✅ **No breaking changes**: Internal code still uses `father`/`mother` (aliased from Sanity)

### Testing
- ✅ `npm run build` - Passed with no errors
- ✅ TypeScript compilation - No type errors
- ✅ All existing functionality preserved

### Verification Steps
1. Export event data to XLSX
2. Open generated Excel file
3. Verify "พ่อ" and "แม่" columns contain data (not empty)
4. Export event data to DOCX
5. Verify pedigree section shows father/mother names

---

Fixes #37