### PR TITLE
fix father mother bug. in export xlsx

### DIFF
--- a/src/server/api/routers/r-sanity.ts
+++ b/src/server/api/routers/r-sanity.ts
@@ -240,8 +240,8 @@ export const sanityRouter = createTRPCRouter({
         ownerName,
         microchip,
         birthday,
-        father,
-        mother,
+        "father": fatherName,
+        "mother": motherName,
         createdAt,
         updatedAt
       } | order(createdAt desc)`;
@@ -281,8 +281,8 @@ export const sanityRouter = createTRPCRouter({
           ownerTel,
           microchip,
           name,
-          father,
-          mother,
+          "father": fatherName,
+          "mother": motherName,
           birthday,
           createdAt,
           updatedAt
@@ -321,8 +321,8 @@ export const sanityRouter = createTRPCRouter({
           ownerTel,
           microchip,
           name,
-          father,
-          mother,
+          "father": fatherName,
+          "mother": motherName,
           birthday,
           createdAt,
           updatedAt
@@ -398,8 +398,8 @@ export const sanityRouter = createTRPCRouter({
             type,
             level,
             birthday,
-            father,
-            mother,
+            "father": fatherName,
+            "mother": motherName,
             "event": event->{title}
           }`
         );
@@ -534,8 +534,8 @@ export const sanityRouter = createTRPCRouter({
             type,
             level,
             birthday,
-            father,
-            mother,
+            "father": fatherName,
+            "mother": motherName,
             "event": event->{title}
           }`
         );


### PR DESCRIPTION
This pull request updates how parent information is handled in several queries within the `sanityRouter` in `src/server/api/routers/r-sanity.ts`. The main change is that the fields for father and mother now explicitly reference `fatherName` and `motherName` instead of using the previous `father` and `mother` fields. This ensures that the returned data contains the correct parent names.

**Query field updates:**

* Changed the query results to use `"father": fatherName` and `"mother": motherName` instead of the original `father` and `mother` fields in multiple query definitions. [[1]](diffhunk://#diff-74375259a33a752ceda688fd5a7025d9bdf42f5d63c036cda237db6615768dc7L243-R244) [[2]](diffhunk://#diff-74375259a33a752ceda688fd5a7025d9bdf42f5d63c036cda237db6615768dc7L284-R285) [[3]](diffhunk://#diff-74375259a33a752ceda688fd5a7025d9bdf42f5d63c036cda237db6615768dc7L324-R325) [[4]](diffhunk://#diff-74375259a33a752ceda688fd5a7025d9bdf42f5d63c036cda237db6615768dc7L401-R402) [[5]](diffhunk://#diff-74375259a33a752ceda688fd5a7025d9bdf42f5d63c036cda237db6615768dc7L537-R538)