### PR TITLE
feat(cert): add Phase B diagnostic logging to createCertificateBypass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+.tmp
 
 # dependencies
 /node_modules


### PR DESCRIPTION
�� Changed Files:
- src/server/services/certificate.service.ts: Add 15 console.log statements with [PHASE_B_LOG] prefix
- .gitignore: Add .tmp/ folder

🔍 Purpose:
- Measure execution time for each step (pedigree check, owner check, approvers loop, transaction)
- Identify bottlenecks causing 504 timeout (suspected: Step 3 approver loop + Step 5b connect loop)
- Non-invasive logging - no business logic changes

📊 Metrics Captured:
- Step 1: Pedigree lookup time
- Step 2: Owner user lookup time
- Step 3: Approvers validation loop time (3 findUnique calls)
- Step 4: Existing certificate check time
- Step 5a: Certificate create/update time
- Step 5b: Approvers connection loop time (up to 3 update calls)
- Total elapsed time

🗑️ Easy Removal:
- All logs use [PHASE_B_LOG] prefix for easy grep/removal
- Removal script: .tmp/remove-phase-b-logs.sh
- Removal guide: .tmp/REMOVE-PHASE-B-LOGS.md

🔄 Rollback: git reset --hard HEAD~1

🧪 Tests: Build ✅ Lint ✅ Types ✅

Related: #41 Phase B