### PR TITLE
Add news admin dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,8 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/jaothui-dashboard"
 SANITY_PROJECT_ID="your-sanity-project-id"
 SANITY_DATASET="production"
 SANITY_API_TOKEN="your-sanity-api-token"
+
+# JAOTHUI news/events admin proxy
+# Shared with jaothui-frontend's server-side JAOTHUI_NEWS_ADMIN_API_KEY.
+JAOTHUI_NEWS_ADMIN_API_BASE_URL="https://www.jaothui.com"
+JAOTHUI_NEWS_ADMIN_API_KEY="replace-with-shared-news-admin-api-key"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "lint": "next lint",
     "start": "next start",
     "test": "jest",
+    "test:news-admin-env": "node scripts/news-admin-env-contract-smoke.mjs",
+    "test:news-admin-proxy": "jest src/server/services/__tests__/news-admin-api-client.test.ts --runInBand",
+    "test:news-admin-ui": "node scripts/news-admin-ui-contract-smoke.mjs",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
   },

--- a/scripts/news-admin-env-contract-smoke.mjs
+++ b/scripts/news-admin-env-contract-smoke.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const envSource = fs.readFileSync(path.join(root, "src/env.js"), "utf8");
+const envExample = fs.readFileSync(path.join(root, ".env.example"), "utf8");
+const routerRootSource = fs.readFileSync(
+  path.join(root, "src/server/api/root.ts"),
+  "utf8"
+);
+const newsEventsRouterSource = fs.existsSync(
+  path.join(root, "src/server/api/routers/r-news-events.ts")
+)
+  ? fs.readFileSync(
+      path.join(root, "src/server/api/routers/r-news-events.ts"),
+      "utf8"
+    )
+  : "";
+const newsAdminClientSource = fs.existsSync(
+  path.join(root, "src/server/services/news-admin-api-client.ts")
+)
+  ? fs.readFileSync(
+      path.join(root, "src/server/services/news-admin-api-client.ts"),
+      "utf8"
+    )
+  : "";
+
+for (const key of [
+  "JAOTHUI_NEWS_ADMIN_API_BASE_URL",
+  "JAOTHUI_NEWS_ADMIN_API_KEY",
+]) {
+  assert.match(envSource, new RegExp(`${key}: z\\.string\\(\\)`), `${key} must be in server schema`);
+  assert.match(envSource, new RegExp(`process\\.env\\.${key}`), `${key} must be in runtimeEnv`);
+  assert.match(envExample, new RegExp(`^${key}=`, "m"), `${key} must be documented in .env.example`);
+}
+
+assert.doesNotMatch(
+  envSource,
+  /NEXT_PUBLIC_JAOTHUI_NEWS_ADMIN_API_KEY/,
+  "news admin API key must not be public"
+);
+
+if (newsEventsRouterSource) {
+  assert.match(
+    routerRootSource,
+    /newsEvents:\s*newsEventsRouter/,
+    "newsEvents router must be registered in appRouter"
+  );
+  assert.doesNotMatch(
+    newsEventsRouterSource,
+    /publicProcedure/,
+    "newsEvents router must not expose public procedures"
+  );
+  assert.match(
+    newsEventsRouterSource,
+    /protectProcedure/,
+    "newsEvents router must use protected procedures"
+  );
+}
+
+if (newsAdminClientSource) {
+  assert.match(
+    newsAdminClientSource,
+    /Authorization/,
+    "news admin client must attach Authorization header server-side"
+  );
+  assert.match(
+    newsAdminClientSource,
+    /JAOTHUI_NEWS_ADMIN_API_KEY/,
+    "news admin client must read the server bridge key"
+  );
+  assert.doesNotMatch(
+    newsAdminClientSource,
+    /NEXT_PUBLIC_JAOTHUI_NEWS_ADMIN_API_KEY/,
+    "news admin client must not use a public bridge key"
+  );
+}
+
+console.log("news admin dashboard env contract smoke passed");

--- a/scripts/news-admin-ui-contract-smoke.mjs
+++ b/scripts/news-admin-ui-contract-smoke.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+const dashboardSource = fs.readFileSync(
+  path.join(root, "src/pages/dashboard/index..tsx"),
+  "utf8"
+);
+const pagePath = path.join(root, "src/pages/dashboard/news-events/index.tsx");
+const pageSource = fs.readFileSync(pagePath, "utf8");
+
+assert.match(
+  dashboardSource,
+  /href="\/dashboard\/news-events"/,
+  "dashboard must link to the news/events admin route"
+);
+assert.match(
+  dashboardSource,
+  /จัดการข่าวสาร/,
+  "dashboard card title must be present"
+);
+
+for (const procedure of [
+  "list",
+  "create",
+  "update",
+  "publish",
+  "archive",
+  "uploadCover",
+]) {
+  assert.match(
+    pageSource,
+    new RegExp(`api\\.newsEvents\\.${procedure}\\.use`),
+    `news/events page must use newsEvents.${procedure}`
+  );
+}
+
+for (const control of [
+  "type=\"datetime-local\"",
+  "type=\"file\"",
+  "type=\"checkbox\"",
+  "aspect-video",
+  "Featured",
+  "Publish",
+  "Archive",
+]) {
+  assert.match(pageSource, new RegExp(control), `missing UI control: ${control}`);
+}
+
+assert.doesNotMatch(
+  pageSource,
+  /JAOTHUI_NEWS_ADMIN_API_KEY|NEXT_PUBLIC_JAOTHUI_NEWS_ADMIN_API_KEY/,
+  "news/events page must not reference bridge secrets"
+);
+assert.doesNotMatch(
+  pageSource,
+  /@sanity\/client|next-sanity|SANITY_PROJECT_ID/,
+  "news/events page must not connect to Sanity directly"
+);
+
+console.log("news admin dashboard UI contract smoke passed");

--- a/src/env.js
+++ b/src/env.js
@@ -14,6 +14,8 @@ export const env = createEnv({
     SANITY_PROJECT_ID: z.string().optional(),
     SANITY_DATASET: z.string().default("production"),
     SANITY_API_TOKEN: z.string().optional(),
+    JAOTHUI_NEWS_ADMIN_API_BASE_URL: z.string().url().optional(),
+    JAOTHUI_NEWS_ADMIN_API_KEY: z.string().optional(),
   },
 
   /**
@@ -35,6 +37,9 @@ export const env = createEnv({
     SANITY_PROJECT_ID: process.env.SANITY_PROJECT_ID,
     SANITY_DATASET: process.env.SANITY_DATASET,
     SANITY_API_TOKEN: process.env.SANITY_API_TOKEN,
+    JAOTHUI_NEWS_ADMIN_API_BASE_URL:
+      process.env.JAOTHUI_NEWS_ADMIN_API_BASE_URL,
+    JAOTHUI_NEWS_ADMIN_API_KEY: process.env.JAOTHUI_NEWS_ADMIN_API_KEY,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
   /**

--- a/src/pages/dashboard/index..tsx
+++ b/src/pages/dashboard/index..tsx
@@ -6,7 +6,8 @@ import {
   Trophy,
   Dna,
   Export,
-  FileLock
+  FileLock,
+  NewspaperClipping
 } from "@phosphor-icons/react";
 import Header from "~/components/ui/Header";
 import DashboardCard from "~/components/ui/DashboardCard";
@@ -67,6 +68,12 @@ const Dashboard = () => {
               icon={<FileLock weight="duotone" />}
               href="/dashboard/certificate-approvment"
               variant="orange"
+            />
+            <DashboardCard
+              title="จัดการข่าวสาร"
+              icon={<NewspaperClipping weight="duotone" />}
+              href="/dashboard/news-events"
+              variant="purple"
             />
           </CardGrid>
         </div>

--- a/src/pages/dashboard/news-events/index.tsx
+++ b/src/pages/dashboard/news-events/index.tsx
@@ -1,0 +1,717 @@
+import {
+  Archive,
+  CalendarBlank,
+  CheckCircle,
+  FloppyDisk,
+  ImageSquare,
+  MagnifyingGlass,
+  NewspaperClipping,
+  PencilSimpleLine,
+  Plus,
+  Star,
+  UploadSimple,
+} from "@phosphor-icons/react";
+import Head from "next/head";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "react-hot-toast";
+import AmbientOrbs from "~/components/ui/AmbientOrbs";
+import Header from "~/components/ui/Header";
+import { api, type RouterInputs, type RouterOutputs } from "~/utils/api";
+
+type NewsEventItem = RouterOutputs["newsEvents"]["list"]["items"][number];
+type NewsEventFormInput = RouterInputs["newsEvents"]["create"];
+
+type StatusFilter = "all" | NewsEventItem["status"];
+type TypeFilter = "all" | NewsEventItem["type"];
+
+interface FormState {
+  id?: string;
+  title: string;
+  slug: string;
+  type: NewsEventItem["type"];
+  status: NewsEventItem["status"];
+  featured: boolean;
+  priority: number;
+  publishedAt: string;
+  eventStartAt: string;
+  eventEndAt: string;
+  location: string;
+  excerpt: string;
+  coverImageUrl: string;
+  coverImageAssetRef: string;
+  ctaLabel: string;
+  ctaUrl: string;
+  body: string;
+}
+
+const emptyForm = (): FormState => ({
+  title: "",
+  slug: "",
+  type: "news",
+  status: "draft",
+  featured: false,
+  priority: 100,
+  publishedAt: toDateTimeLocalValue(new Date().toISOString()),
+  eventStartAt: "",
+  eventEndAt: "",
+  location: "",
+  excerpt: "",
+  coverImageUrl: "",
+  coverImageAssetRef: "",
+  ctaLabel: "",
+  ctaUrl: "",
+  body: "",
+});
+
+const statusMeta = {
+  draft: {
+    label: "ร่าง",
+    className: "border-white/10 bg-white/10 text-white",
+  },
+  published: {
+    label: "เผยแพร่",
+    className: "border-emerald-400/30 bg-emerald-400/15 text-emerald-200",
+  },
+  archived: {
+    label: "เก็บถาวร",
+    className: "border-red-400/30 bg-red-400/15 text-red-200",
+  },
+} satisfies Record<NewsEventItem["status"], { label: string; className: string }>;
+
+const typeMeta = {
+  news: "ข่าว",
+  event: "กิจกรรม",
+  announcement: "ประกาศ",
+} satisfies Record<NewsEventItem["type"], string>;
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9ก-๙-]/g, "")
+    .slice(0, 140);
+}
+
+function toDateTimeLocalValue(value: string | null) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function fromDateTimeLocalValue(value: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function toFormState(item: NewsEventItem): FormState {
+  return {
+    id: item.id,
+    title: item.title,
+    slug: item.slug,
+    type: item.type,
+    status: item.status,
+    featured: item.featured,
+    priority: item.priority,
+    publishedAt: toDateTimeLocalValue(item.publishedAt),
+    eventStartAt: toDateTimeLocalValue(item.eventStartAt),
+    eventEndAt: toDateTimeLocalValue(item.eventEndAt),
+    location: item.location ?? "",
+    excerpt: item.excerpt,
+    coverImageUrl: item.coverImageUrl ?? "",
+    coverImageAssetRef: item.coverImageAssetRef ?? "",
+    ctaLabel: item.ctaLabel ?? "",
+    ctaUrl: item.ctaUrl ?? "",
+    body: "",
+  };
+}
+
+function toMutationInput(form: FormState): NewsEventFormInput {
+  return {
+    title: form.title.trim(),
+    slug: slugify(form.slug),
+    type: form.type,
+    status: form.status,
+    featured: form.featured,
+    priority: Number.isFinite(form.priority) ? form.priority : 100,
+    publishedAt: fromDateTimeLocalValue(form.publishedAt),
+    eventStartAt: form.type === "event" ? fromDateTimeLocalValue(form.eventStartAt) : null,
+    eventEndAt: form.type === "event" ? fromDateTimeLocalValue(form.eventEndAt) : null,
+    location: form.type === "event" && form.location.trim() ? form.location.trim() : null,
+    excerpt: form.excerpt.trim(),
+    coverImageAssetRef: form.coverImageAssetRef || null,
+    ctaLabel: form.ctaLabel.trim() || null,
+    ctaUrl: form.ctaUrl.trim() || null,
+    body: form.body.trim() || null,
+  };
+}
+
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      resolve(result.split(",")[1] ?? "");
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function isPublishable(form: FormState) {
+  return Boolean(form.title.trim() && form.slug.trim() && form.excerpt.trim() && form.publishedAt);
+}
+
+export default function NewsEventsAdminPage() {
+  const utils = api.useUtils();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(() => emptyForm());
+
+  const newsEventsQuery = api.newsEvents.list.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+  const createMutation = api.newsEvents.create.useMutation();
+  const updateMutation = api.newsEvents.update.useMutation();
+  const publishMutation = api.newsEvents.publish.useMutation();
+  const archiveMutation = api.newsEvents.archive.useMutation();
+  const uploadMutation = api.newsEvents.uploadCover.useMutation();
+
+  const items = useMemo(
+    () => newsEventsQuery.data?.items ?? [],
+    [newsEventsQuery.data?.items],
+  );
+  const selectedItem = items.find((item) => item.id === selectedId) ?? null;
+
+  useEffect(() => {
+    if (selectedItem) {
+      setForm(toFormState(selectedItem));
+    }
+  }, [selectedItem]);
+
+  const filteredItems = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return items.filter((item) => {
+      const matchesQuery =
+        !normalizedQuery ||
+        [item.title, item.slug, item.excerpt, item.location ?? ""]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedQuery);
+      const matchesStatus = statusFilter === "all" || item.status === statusFilter;
+      const matchesType = typeFilter === "all" || item.type === typeFilter;
+      return matchesQuery && matchesStatus && matchesType;
+    });
+  }, [items, query, statusFilter, typeFilter]);
+
+  const refreshList = async () => {
+    await utils.newsEvents.list.invalidate();
+  };
+
+  const selectNewDraft = () => {
+    setSelectedId(null);
+    setForm(emptyForm());
+  };
+
+  const updateForm = <Key extends keyof FormState>(key: Key, value: FormState[Key]) => {
+    setForm((current) => ({
+      ...current,
+      [key]: value,
+      ...(key === "title" && !current.id ? { slug: slugify(String(value)) } : {}),
+    }));
+  };
+
+  const handleSave = async () => {
+    const input = toMutationInput(form);
+    if (!input.title || !input.slug || !input.excerpt) {
+      toast.error("กรอกหัวข้อ, slug และคำโปรยให้ครบก่อนบันทึก");
+      return;
+    }
+
+    try {
+      const response = form.id
+        ? await updateMutation.mutateAsync({ id: form.id, data: input })
+        : await createMutation.mutateAsync(input);
+      await refreshList();
+      setSelectedId(response.item.id);
+      setForm(toFormState(response.item));
+      toast.success("บันทึกข่าวสารแล้ว");
+    } catch (error) {
+      console.error("Save news event failed", error);
+      toast.error("บันทึกข่าวสารไม่สำเร็จ");
+    }
+  };
+
+  const handlePublish = async () => {
+    if (!form.id || !isPublishable(form)) {
+      toast.error("ต้องมีหัวข้อ, slug, คำโปรย และวันเผยแพร่ก่อน publish");
+      return;
+    }
+
+    try {
+      const response = await publishMutation.mutateAsync({ id: form.id });
+      await refreshList();
+      setForm(toFormState(response.item));
+      toast.success("เผยแพร่ข่าวสารแล้ว");
+    } catch (error) {
+      console.error("Publish news event failed", error);
+      toast.error("เผยแพร่ไม่สำเร็จ");
+    }
+  };
+
+  const handleArchive = async () => {
+    if (!form.id) return;
+
+    try {
+      const response = await archiveMutation.mutateAsync({ id: form.id });
+      await refreshList();
+      setForm(toFormState(response.item));
+      toast.success("เก็บข่าวสารแล้ว");
+    } catch (error) {
+      console.error("Archive news event failed", error);
+      toast.error("เก็บข่าวสารไม่สำเร็จ");
+    }
+  };
+
+  const handleCoverUpload = async (file: File | undefined) => {
+    if (!file) return;
+
+    try {
+      const base64 = await readFileAsBase64(file);
+      const response = await uploadMutation.mutateAsync({
+        filename: file.name,
+        contentType: file.type,
+        base64,
+      });
+      setForm((current) => ({
+        ...current,
+        coverImageAssetRef: response.asset.assetRef,
+        coverImageUrl: response.asset.url ?? current.coverImageUrl,
+      }));
+      toast.success("อัปโหลดรูปแล้ว");
+    } catch (error) {
+      console.error("Cover upload failed", error);
+      toast.error("อัปโหลดรูปไม่สำเร็จ");
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+  const isPublishing = publishMutation.isPending;
+  const isArchiving = archiveMutation.isPending;
+
+  return (
+    <>
+      <Head>
+        <title>จัดการข่าวสาร | Jaothui Dashboard</title>
+      </Head>
+      <div className="relative min-h-screen bg-dark text-white">
+        <AmbientOrbs />
+        <Header />
+
+        <main className="relative z-10 mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 pb-12 pt-8 sm:px-6">
+          <section className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-primary-orange/30 bg-primary-orange/10 px-3 py-1 text-sm font-medium text-primary-orange-glow">
+                <NewspaperClipping weight="duotone" />
+                News & Events
+              </div>
+              <h1 className="text-2xl font-semibold text-white md:text-3xl">
+                จัดการข่าวสาร
+              </h1>
+            </div>
+
+            <button
+              type="button"
+              onClick={selectNewDraft}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-primary-orange px-4 py-2 text-sm font-semibold text-black transition hover:bg-primary-orange-glow focus:outline-none focus:ring-2 focus:ring-primary-orange/60"
+            >
+              <Plus weight="bold" />
+              สร้างข่าว
+            </button>
+          </section>
+
+          <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_420px]">
+            <div className="space-y-4">
+              <div className="glass-card rounded-3xl p-4">
+                <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_160px_160px]">
+                  <label className="relative block">
+                    <MagnifyingGlass className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-white/45" />
+                    <input
+                      value={query}
+                      onChange={(event) => setQuery(event.target.value)}
+                      placeholder="ค้นหาหัวข้อ, slug, สถานที่"
+                      className="h-12 w-full rounded-xl border border-white/10 bg-black/30 pl-11 pr-4 text-sm text-white outline-none transition placeholder:text-white/35 focus:border-primary-orange/70"
+                    />
+                  </label>
+
+                  <select
+                    value={statusFilter}
+                    onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
+                    className="h-12 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none transition focus:border-primary-orange/70"
+                  >
+                    <option value="all">ทุกสถานะ</option>
+                    <option value="draft">ร่าง</option>
+                    <option value="published">เผยแพร่</option>
+                    <option value="archived">เก็บถาวร</option>
+                  </select>
+
+                  <select
+                    value={typeFilter}
+                    onChange={(event) => setTypeFilter(event.target.value as TypeFilter)}
+                    className="h-12 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none transition focus:border-primary-orange/70"
+                  >
+                    <option value="all">ทุกประเภท</option>
+                    <option value="news">ข่าว</option>
+                    <option value="event">กิจกรรม</option>
+                    <option value="announcement">ประกาศ</option>
+                  </select>
+                </div>
+              </div>
+
+              <div className="grid gap-3">
+                {newsEventsQuery.isLoading ? (
+                  <div className="glass-card rounded-3xl p-8 text-center text-white/70">
+                    กำลังโหลดข่าวสาร...
+                  </div>
+                ) : null}
+
+                {newsEventsQuery.error ? (
+                  <div className="rounded-3xl border border-red-400/30 bg-red-400/10 p-5 text-red-100">
+                    โหลดข่าวสารไม่สำเร็จ
+                  </div>
+                ) : null}
+
+                {!newsEventsQuery.isLoading && filteredItems.length === 0 ? (
+                  <div className="glass-card rounded-3xl p-8 text-center text-white/70">
+                    ไม่พบรายการ
+                  </div>
+                ) : null}
+
+                {filteredItems.map((item) => {
+                  const isSelected = item.id === form.id;
+                  return (
+                    <button
+                      type="button"
+                      key={item.id}
+                      onClick={() => setSelectedId(item.id)}
+                      className={`glass-card group grid gap-4 rounded-3xl p-4 text-left transition hover:border-primary-orange/50 md:grid-cols-[160px_minmax(0,1fr)] ${
+                        isSelected ? "border-primary-orange/60 shadow-orange-glow" : ""
+                      }`}
+                    >
+                      <div className="aspect-video overflow-hidden rounded-xl border border-white/10 bg-black/40">
+                        {item.coverImageUrl ? (
+                          <div
+                            aria-hidden="true"
+                            className="h-full w-full bg-cover bg-center"
+                            style={{ backgroundImage: `url(${item.coverImageUrl})` }}
+                          />
+                        ) : (
+                          <div className="flex h-full items-center justify-center text-white/30">
+                            <ImageSquare size={32} weight="duotone" />
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="min-w-0 space-y-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span
+                            className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${statusMeta[item.status].className}`}
+                          >
+                            {statusMeta[item.status].label}
+                          </span>
+                          <span className="inline-flex items-center rounded-full border border-accent-purple/30 bg-accent-purple/15 px-2.5 py-1 text-xs font-medium text-purple-100">
+                            {typeMeta[item.type]}
+                          </span>
+                          {item.featured ? (
+                            <span className="inline-flex items-center gap-1 rounded-full border border-primary-orange/30 bg-primary-orange/10 px-2.5 py-1 text-xs font-medium text-primary-orange-glow">
+                              <Star size={13} weight="fill" />
+                              Featured
+                            </span>
+                          ) : null}
+                        </div>
+
+                        <div>
+                          <h2 className="line-clamp-2 break-words text-lg font-semibold text-white">
+                            {item.title}
+                          </h2>
+                          <p className="mt-1 line-clamp-2 break-words text-sm text-white/60">
+                            {item.excerpt}
+                          </p>
+                        </div>
+
+                        <div className="flex flex-wrap items-center gap-3 text-xs text-white/45">
+                          <span>Priority {item.priority}</span>
+                          <span>{item.slug}</span>
+                          {item.publishedAt ? (
+                            <span className="inline-flex items-center gap-1">
+                              <CalendarBlank />
+                              {new Date(item.publishedAt).toLocaleDateString("th-TH")}
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <aside className="glass-card h-fit rounded-3xl p-5 lg:sticky lg:top-28">
+              <div className="mb-5 flex items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-white">
+                    {form.id ? "แก้ไขรายการ" : "สร้างรายการ"}
+                  </h2>
+                  <p className="text-sm text-white/50">
+                    {form.id ? form.slug || form.id : "draft"}
+                  </p>
+                </div>
+                <PencilSimpleLine className="text-2xl text-primary-orange-glow" />
+              </div>
+
+              <div className="space-y-4">
+                <div className="aspect-video overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                  {form.coverImageUrl ? (
+                    <div
+                      aria-hidden="true"
+                      className="h-full w-full bg-cover bg-center"
+                      style={{ backgroundImage: `url(${form.coverImageUrl})` }}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      className="flex h-full w-full flex-col items-center justify-center gap-2 text-white/40 transition hover:text-white/70"
+                    >
+                      <ImageSquare size={42} weight="duotone" />
+                      <span className="text-sm">16:9 Cover</span>
+                    </button>
+                  )}
+                </div>
+
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  className="hidden"
+                  onChange={(event) => void handleCoverUpload(event.target.files?.[0])}
+                />
+
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploadMutation.isPending}
+                  className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <UploadSimple />
+                  {uploadMutation.isPending ? "กำลังอัปโหลด..." : "อัปโหลดรูป"}
+                </button>
+
+                <div className="grid gap-3">
+                  <label className="grid gap-1.5">
+                    <span className="text-sm text-white/70">หัวข้อ</span>
+                    <input
+                      value={form.title}
+                      onChange={(event) => updateForm("title", event.target.value)}
+                      maxLength={120}
+                      className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                    />
+                  </label>
+
+                  <label className="grid gap-1.5">
+                    <span className="text-sm text-white/70">Slug</span>
+                    <input
+                      value={form.slug}
+                      onChange={(event) => updateForm("slug", slugify(event.target.value))}
+                      maxLength={140}
+                      className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                    />
+                  </label>
+
+                  <label className="grid gap-1.5">
+                    <span className="text-sm text-white/70">คำโปรย</span>
+                    <textarea
+                      value={form.excerpt}
+                      onChange={(event) => updateForm("excerpt", event.target.value)}
+                      maxLength={240}
+                      rows={3}
+                      className="resize-none rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-primary-orange/70"
+                    />
+                  </label>
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <label className="grid gap-1.5">
+                      <span className="text-sm text-white/70">ประเภท</span>
+                      <select
+                        value={form.type}
+                        onChange={(event) => updateForm("type", event.target.value as FormState["type"])}
+                        className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                      >
+                        <option value="news">ข่าว</option>
+                        <option value="event">กิจกรรม</option>
+                        <option value="announcement">ประกาศ</option>
+                      </select>
+                    </label>
+
+                    <label className="grid gap-1.5">
+                      <span className="text-sm text-white/70">สถานะ</span>
+                      <select
+                        value={form.status}
+                        onChange={(event) => updateForm("status", event.target.value as FormState["status"])}
+                        className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                      >
+                        <option value="draft">ร่าง</option>
+                        <option value="published">เผยแพร่</option>
+                        <option value="archived">เก็บถาวร</option>
+                      </select>
+                    </label>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <label className="grid gap-1.5">
+                      <span className="text-sm text-white/70">วันเผยแพร่</span>
+                      <input
+                        type="datetime-local"
+                        value={form.publishedAt}
+                        onChange={(event) => updateForm("publishedAt", event.target.value)}
+                        className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                      />
+                    </label>
+
+                    <label className="grid gap-1.5">
+                      <span className="text-sm text-white/70">Priority</span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={999}
+                        value={form.priority}
+                        onChange={(event) => updateForm("priority", Number(event.target.value))}
+                        className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                      />
+                    </label>
+                  </div>
+
+                  <label className="flex min-h-11 items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white">
+                    <span className="inline-flex items-center gap-2">
+                      <Star className="text-primary-orange-glow" weight={form.featured ? "fill" : "regular"} />
+                      Featured
+                    </span>
+                    <input
+                      type="checkbox"
+                      checked={form.featured}
+                      onChange={(event) => updateForm("featured", event.target.checked)}
+                      className="toggle toggle-warning toggle-sm"
+                    />
+                  </label>
+
+                  {form.type === "event" ? (
+                    <div className="grid gap-3 rounded-2xl border border-accent-purple/20 bg-accent-purple/10 p-3">
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <label className="grid gap-1.5">
+                          <span className="text-sm text-white/70">เริ่มกิจกรรม</span>
+                          <input
+                            type="datetime-local"
+                            value={form.eventStartAt}
+                            onChange={(event) => updateForm("eventStartAt", event.target.value)}
+                            className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                          />
+                        </label>
+                        <label className="grid gap-1.5">
+                          <span className="text-sm text-white/70">จบกิจกรรม</span>
+                          <input
+                            type="datetime-local"
+                            value={form.eventEndAt}
+                            onChange={(event) => updateForm("eventEndAt", event.target.value)}
+                            className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                          />
+                        </label>
+                      </div>
+                      <label className="grid gap-1.5">
+                        <span className="text-sm text-white/70">สถานที่</span>
+                        <input
+                          value={form.location}
+                          onChange={(event) => updateForm("location", event.target.value)}
+                          maxLength={160}
+                          className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                        />
+                      </label>
+                    </div>
+                  ) : null}
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <label className="grid gap-1.5">
+                      <span className="text-sm text-white/70">CTA Label</span>
+                      <input
+                        value={form.ctaLabel}
+                        onChange={(event) => updateForm("ctaLabel", event.target.value)}
+                        maxLength={40}
+                        className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                      />
+                    </label>
+                    <label className="grid gap-1.5">
+                      <span className="text-sm text-white/70">CTA URL</span>
+                      <input
+                        value={form.ctaUrl}
+                        onChange={(event) => updateForm("ctaUrl", event.target.value)}
+                        className="h-11 rounded-xl border border-white/10 bg-black/30 px-3 text-sm text-white outline-none focus:border-primary-orange/70"
+                      />
+                    </label>
+                  </div>
+
+                  <label className="grid gap-1.5">
+                    <span className="text-sm text-white/70">Body</span>
+                    <textarea
+                      value={form.body}
+                      onChange={(event) => updateForm("body", event.target.value)}
+                      maxLength={6000}
+                      rows={4}
+                      className="resize-none rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-primary-orange/70"
+                    />
+                  </label>
+                </div>
+
+                <div className="grid gap-2 sm:grid-cols-3">
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={isSaving}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-primary-orange px-3 py-2 text-sm font-semibold text-black transition hover:bg-primary-orange-glow disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <FloppyDisk />
+                    {isSaving ? "กำลังบันทึก" : "บันทึก"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handlePublish}
+                    disabled={!form.id || !isPublishable(form) || isPublishing}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-emerald-400/30 bg-emerald-400/15 px-3 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-400/25 disabled:cursor-not-allowed disabled:opacity-45"
+                  >
+                    <CheckCircle />
+                    Publish
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleArchive}
+                    disabled={!form.id || isArchiving}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-red-400/30 bg-red-400/15 px-3 py-2 text-sm font-semibold text-red-100 transition hover:bg-red-400/25 disabled:cursor-not-allowed disabled:opacity-45"
+                  >
+                    <Archive />
+                    Archive
+                  </button>
+                </div>
+              </div>
+            </aside>
+          </section>
+        </main>
+      </div>
+    </>
+  );
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -8,6 +8,7 @@ import { rewardRouter } from "./routers/r-reward";
 import { dnaRouter } from "./routers/r-dna";
 import { certRouter } from "./routers/r-certificate";
 import { sanityRouter } from "./routers/r-sanity";
+import { newsEventsRouter } from "./routers/r-news-events";
 
 /**
  * This is the primary router for your server.
@@ -24,6 +25,7 @@ export const appRouter = createTRPCRouter({
   dna: dnaRouter,
   cert: certRouter,
   sanity: sanityRouter,
+  newsEvents: newsEventsRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/r-news-events.ts
+++ b/src/server/api/routers/r-news-events.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+import { createTRPCRouter, protectProcedure } from "~/server/api/trpc";
+import {
+  newsAdminApiClient,
+  newsEventAdminUpsertInputSchema,
+  toNewsAdminTRPCError,
+  uploadNewsEventCoverInputSchema,
+} from "~/server/services/news-admin-api-client";
+
+const idInputSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const newsEventsRouter = createTRPCRouter({
+  list: protectProcedure.query(async () => {
+    try {
+      return await newsAdminApiClient.list();
+    } catch (error) {
+      throw toNewsAdminTRPCError(error);
+    }
+  }),
+
+  getById: protectProcedure.input(idInputSchema).query(async ({ input }) => {
+    try {
+      return await newsAdminApiClient.getById(input.id);
+    } catch (error) {
+      throw toNewsAdminTRPCError(error);
+    }
+  }),
+
+  create: protectProcedure
+    .input(newsEventAdminUpsertInputSchema)
+    .mutation(async ({ input }) => {
+      try {
+        return await newsAdminApiClient.create(input);
+      } catch (error) {
+        throw toNewsAdminTRPCError(error);
+      }
+    }),
+
+  update: protectProcedure
+    .input(
+      z.object({
+        id: z.string().min(1),
+        data: newsEventAdminUpsertInputSchema,
+      }),
+    )
+    .mutation(async ({ input }) => {
+      try {
+        return await newsAdminApiClient.update(input.id, input.data);
+      } catch (error) {
+        throw toNewsAdminTRPCError(error);
+      }
+    }),
+
+  publish: protectProcedure.input(idInputSchema).mutation(async ({ input }) => {
+    try {
+      return await newsAdminApiClient.publish(input.id);
+    } catch (error) {
+      throw toNewsAdminTRPCError(error);
+    }
+  }),
+
+  archive: protectProcedure.input(idInputSchema).mutation(async ({ input }) => {
+    try {
+      return await newsAdminApiClient.archive(input.id);
+    } catch (error) {
+      throw toNewsAdminTRPCError(error);
+    }
+  }),
+
+  uploadCover: protectProcedure
+    .input(uploadNewsEventCoverInputSchema)
+    .mutation(async ({ input }) => {
+      try {
+        return await newsAdminApiClient.uploadCover(input);
+      } catch (error) {
+        throw toNewsAdminTRPCError(error);
+      }
+    }),
+});

--- a/src/server/services/__tests__/news-admin-api-client.test.ts
+++ b/src/server/services/__tests__/news-admin-api-client.test.ts
@@ -1,0 +1,168 @@
+jest.mock("~/env", () => ({
+  env: {
+    JAOTHUI_NEWS_ADMIN_API_BASE_URL: "http://localhost:3000",
+    JAOTHUI_NEWS_ADMIN_API_KEY: "test-news-admin-api-key",
+  },
+}));
+
+import {
+  newsAdminApiClient,
+  toNewsAdminTRPCError,
+  type NewsEventAdminItem,
+} from "../news-admin-api-client";
+
+const mockItem: NewsEventAdminItem = {
+  id: "news-event-1",
+  title: "ข่าวทดสอบ",
+  slug: "test-news",
+  type: "news",
+  status: "draft",
+  featured: false,
+  priority: 100,
+  publishedAt: null,
+  eventStartAt: null,
+  eventEndAt: null,
+  location: null,
+  excerpt: "รายละเอียดข่าว",
+  coverImageUrl: null,
+  coverImageAssetRef: null,
+  ctaLabel: null,
+  ctaUrl: null,
+};
+
+class TestHeaders {
+  private readonly values = new Map<string, string>();
+
+  constructor(init?: TestHeaders | [string, string][] | Record<string, string>) {
+    if (init instanceof TestHeaders) {
+      init.values.forEach((value, key) => this.values.set(key, value));
+      return;
+    }
+
+    if (Array.isArray(init)) {
+      init.forEach(([key, value]) => this.set(key, value));
+      return;
+    }
+
+    if (init && typeof init === "object") {
+      Object.entries(init).forEach(([key, value]) => this.set(key, value));
+    }
+  }
+
+  get(name: string) {
+    return this.values.get(name.toLowerCase()) ?? null;
+  }
+
+  set(name: string, value: string) {
+    this.values.set(name.toLowerCase(), value);
+  }
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+describe("newsAdminApiClient", () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    global.Headers = TestHeaders as unknown as typeof Headers;
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it("calls the frontend admin API with the server bridge bearer token", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ items: [mockItem] }, 200),
+    );
+
+    const response = await newsAdminApiClient.list();
+
+    expect(response.items).toEqual([mockItem]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe("http://localhost:3000/api/admin/news-events");
+    expect(init.headers).toBeInstanceOf(Headers);
+    expect((init.headers as Headers).get("Authorization")).toMatch(/^Bearer .+/);
+    expect((init.headers as Headers).get("Accept")).toBe("application/json");
+  });
+
+  it("sends JSON mutation payloads without exposing the API key in the body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ item: mockItem }, 201),
+    );
+
+    await newsAdminApiClient.create({
+      title: mockItem.title,
+      slug: mockItem.slug,
+      type: "news",
+      status: "draft",
+      featured: false,
+      priority: 100,
+      publishedAt: null,
+      excerpt: mockItem.excerpt,
+      ctaUrl: "/news",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(init.method).toBe("POST");
+    expect((init.headers as Headers).get("Authorization")).toMatch(/^Bearer .+/);
+    expect(init.body).toContain('"title":"ข่าวทดสอบ"');
+    expect(init.body).not.toContain("JAOTHUI_NEWS_ADMIN_API_KEY");
+  });
+
+  it("maps frontend validation failures to user-safe tRPC bad requests", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: "VALIDATION_ERROR",
+          message: "Cannot publish news event: missing publishedAt",
+        },
+        400,
+      ),
+    );
+
+    try {
+      await newsAdminApiClient.publish("news-event-1");
+      throw new Error("Expected publish to fail");
+    } catch (error) {
+      expect(error).toMatchObject({
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      const trpcError = toNewsAdminTRPCError(error);
+      expect(trpcError.code).toBe("BAD_REQUEST");
+      expect(trpcError.message).toBe("Cannot publish news event: missing publishedAt");
+    }
+  });
+
+  it("uploads cover images through the raw upload route with filename query", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          asset: { assetRef: "image-asset-1", url: "https://cdn.example/cover.jpg" },
+        },
+        200,
+      ),
+    );
+
+    const response = await newsAdminApiClient.uploadCover({
+      filename: "cover.jpg",
+      contentType: "image/jpeg",
+      base64: Buffer.from("image").toString("base64"),
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe(
+      "http://localhost:3000/api/admin/news-events/upload-cover?filename=cover.jpg",
+    );
+    expect(init.method).toBe("POST");
+    expect((init.headers as Headers).get("Content-Type")).toBe("image/jpeg");
+    expect(response.asset.assetRef).toBe("image-asset-1");
+  });
+});

--- a/src/server/services/news-admin-api-client.ts
+++ b/src/server/services/news-admin-api-client.ts
@@ -1,0 +1,300 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { env } from "~/env";
+
+export const newsEventAdminTypeSchema = z.enum([
+  "news",
+  "event",
+  "announcement",
+]);
+
+export const newsEventAdminStatusSchema = z.enum([
+  "draft",
+  "published",
+  "archived",
+]);
+
+export const newsEventAdminItemSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  slug: z.string(),
+  type: newsEventAdminTypeSchema,
+  status: newsEventAdminStatusSchema,
+  featured: z.boolean(),
+  priority: z.number(),
+  publishedAt: z.string().nullable(),
+  eventStartAt: z.string().nullable(),
+  eventEndAt: z.string().nullable(),
+  location: z.string().nullable(),
+  excerpt: z.string(),
+  coverImageUrl: z.string().nullable(),
+  coverImageAssetRef: z.string().nullable(),
+  ctaLabel: z.string().nullable(),
+  ctaUrl: z.string().nullable(),
+});
+
+export const newsEventAdminUpsertInputSchema = z.object({
+  title: z.string().min(1).max(120),
+  slug: z.string().min(1).max(140),
+  type: newsEventAdminTypeSchema.default("news"),
+  status: newsEventAdminStatusSchema.default("draft"),
+  featured: z.boolean().default(false),
+  priority: z.number().int().min(0).max(999).default(100),
+  publishedAt: z.string().datetime().nullable().optional(),
+  eventStartAt: z.string().datetime().nullable().optional(),
+  eventEndAt: z.string().datetime().nullable().optional(),
+  location: z.string().max(160).nullable().optional(),
+  excerpt: z.string().min(1).max(240),
+  coverImageAssetRef: z.string().nullable().optional(),
+  ctaLabel: z.string().max(40).nullable().optional(),
+  ctaUrl: z
+    .string()
+    .refine(
+      (value) => value.startsWith("/") || /^https?:\/\//.test(value),
+      "CTA URL must be relative or HTTP(S)",
+    )
+    .nullable()
+    .optional(),
+  body: z.string().max(6000).nullable().optional(),
+});
+
+const newsEventAdminListResponseSchema = z.object({
+  items: z.array(newsEventAdminItemSchema),
+});
+
+const newsEventAdminMutationResponseSchema = z.object({
+  item: newsEventAdminItemSchema,
+});
+
+const newsEventAdminUploadCoverResponseSchema = z.object({
+  asset: z.object({
+    assetRef: z.string().min(1),
+    url: z.string().nullable(),
+  }),
+});
+
+export const uploadNewsEventCoverInputSchema = z.object({
+  filename: z.string().min(1).max(180),
+  contentType: z.string().startsWith("image/"),
+  base64: z.string().min(1),
+});
+
+export type NewsEventAdminItem = z.infer<typeof newsEventAdminItemSchema>;
+export type NewsEventAdminUpsertInput = z.infer<
+  typeof newsEventAdminUpsertInputSchema
+>;
+export type UploadNewsEventCoverInput = z.infer<
+  typeof uploadNewsEventCoverInputSchema
+>;
+
+interface NewsAdminApiConfig {
+  baseUrl: string;
+  apiKey: string;
+}
+
+export class NewsAdminApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(message: string, status: number, code = "NEWS_ADMIN_API_ERROR") {
+    super(message);
+    this.name = "NewsAdminApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function getNewsAdminApiConfig(): NewsAdminApiConfig {
+  if (!env.JAOTHUI_NEWS_ADMIN_API_BASE_URL || !env.JAOTHUI_NEWS_ADMIN_API_KEY) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "News admin API bridge is not configured",
+    });
+  }
+
+  return {
+    baseUrl: env.JAOTHUI_NEWS_ADMIN_API_BASE_URL,
+    apiKey: env.JAOTHUI_NEWS_ADMIN_API_KEY,
+  };
+}
+
+function buildNewsAdminUrl(
+  config: NewsAdminApiConfig,
+  path: string,
+  searchParams?: Record<string, string>,
+): URL {
+  const url = new URL(
+    path,
+    config.baseUrl.endsWith("/") ? config.baseUrl : `${config.baseUrl}/`,
+  );
+
+  for (const [key, value] of Object.entries(searchParams ?? {})) {
+    url.searchParams.set(key, value);
+  }
+
+  return url;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { message: text };
+  }
+}
+
+function mapApiError(status: number, body: unknown): NewsAdminApiError {
+  const parsed = z
+    .object({
+      error: z.string().optional(),
+      message: z.string().optional(),
+    })
+    .safeParse(body);
+
+  const code = parsed.success
+    ? parsed.data.error ?? "NEWS_ADMIN_API_ERROR"
+    : "NEWS_ADMIN_API_ERROR";
+  const message =
+    parsed.success && parsed.data.message
+      ? parsed.data.message
+      : "News admin API request failed";
+
+  return new NewsAdminApiError(message, status, code);
+}
+
+async function requestNewsAdminApi<T>(
+  path: string,
+  responseSchema: z.ZodType<T>,
+  init: RequestInit = {},
+  searchParams?: Record<string, string>,
+  config = getNewsAdminApiConfig(),
+): Promise<T> {
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${config.apiKey}`);
+  headers.set("Accept", "application/json");
+
+  const response = await fetch(buildNewsAdminUrl(config, path, searchParams), {
+    ...init,
+    headers,
+  });
+
+  const body = await readResponseBody(response);
+  if (!response.ok) {
+    throw mapApiError(response.status, body);
+  }
+
+  return responseSchema.parse(body);
+}
+
+function jsonRequestInit(method: "POST" | "PATCH", body?: unknown): RequestInit {
+  return {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  };
+}
+
+export function toNewsAdminTRPCError(error: unknown): TRPCError {
+  if (error instanceof TRPCError) return error;
+
+  if (error instanceof NewsAdminApiError) {
+    if (error.status === 401 || error.status === 403) {
+      return new TRPCError({
+        code: "UNAUTHORIZED",
+        message: "News admin API rejected the dashboard bridge key",
+        cause: error,
+      });
+    }
+
+    if (error.status === 400 || error.status === 404) {
+      return new TRPCError({
+        code: "BAD_REQUEST",
+        message: error.message,
+        cause: error,
+      });
+    }
+
+    return new TRPCError({
+      code: "BAD_GATEWAY",
+      message: "News admin API request failed",
+      cause: error,
+    });
+  }
+
+  return new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: "Unexpected news admin proxy error",
+    cause: error,
+  });
+}
+
+export const newsAdminApiClient = {
+  async list() {
+    return requestNewsAdminApi(
+      "/api/admin/news-events",
+      newsEventAdminListResponseSchema,
+    );
+  },
+
+  async getById(id: string) {
+    return requestNewsAdminApi(
+      `/api/admin/news-events/${encodeURIComponent(id)}`,
+      newsEventAdminMutationResponseSchema,
+    );
+  },
+
+  async create(input: NewsEventAdminUpsertInput) {
+    return requestNewsAdminApi(
+      "/api/admin/news-events",
+      newsEventAdminMutationResponseSchema,
+      jsonRequestInit("POST", input),
+    );
+  },
+
+  async update(id: string, input: NewsEventAdminUpsertInput) {
+    return requestNewsAdminApi(
+      `/api/admin/news-events/${encodeURIComponent(id)}`,
+      newsEventAdminMutationResponseSchema,
+      jsonRequestInit("PATCH", input),
+    );
+  },
+
+  async publish(id: string) {
+    return requestNewsAdminApi(
+      `/api/admin/news-events/${encodeURIComponent(id)}/publish`,
+      newsEventAdminMutationResponseSchema,
+      jsonRequestInit("POST"),
+    );
+  },
+
+  async archive(id: string) {
+    return requestNewsAdminApi(
+      `/api/admin/news-events/${encodeURIComponent(id)}/archive`,
+      newsEventAdminMutationResponseSchema,
+      jsonRequestInit("POST"),
+    );
+  },
+
+  async uploadCover(input: UploadNewsEventCoverInput) {
+    const bytes = Buffer.from(input.base64, "base64");
+
+    return requestNewsAdminApi(
+      "/api/admin/news-events/upload-cover",
+      newsEventAdminUploadCoverResponseSchema,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": input.contentType,
+        },
+        body: bytes as unknown as BodyInit,
+      },
+      { filename: input.filename },
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- add server-only news admin API client and protected tRPC router
- add `/dashboard/news-events` operator UI for list, create, edit, publish, archive, priority, featured, CTA, event fields, and optional cover upload
- add dashboard entry card and focused env/proxy/UI contract tests

## Dependency
- Requires frontend admin API PR: https://github.com/mojisejr/jaothui-front/pull/178

## Runtime proof
- Phase 4 browser proof passed with the dashboard pointed at local frontend admin API
- operator requested no image upload; cover image is optional by contract
- created, published, verified public visibility on `/api/mobile/v1/news-events` and `/v2`, archived, then verified disappearance
- final browser run: severe console errors 0, failed requests 0
- artifact: `.playwright-mcp/jaothui-dashboard/news-admin-mvp/phase-4-web-eye-result.json`

## Verification
- `npm run test:news-admin-env`
- `npm run test:news-admin-proxy`
- `npm run test:news-admin-ui`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`

Notes: lint/build still report existing project warnings outside this feature.