### PR TITLE
fix: allow news cover uploads through dashboard

### DIFF
--- a/scripts/news-admin-ui-contract-smoke.mjs
+++ b/scripts/news-admin-ui-contract-smoke.mjs
@@ -12,6 +12,10 @@ const dashboardSource = fs.readFileSync(
 );
 const pagePath = path.join(root, "src/pages/dashboard/news-events/index.tsx");
 const pageSource = fs.readFileSync(pagePath, "utf8");
+const trpcRouteSource = fs.readFileSync(
+  path.join(root, "src/pages/api/trpc/[trpc].ts"),
+  "utf8"
+);
 
 assert.match(
   dashboardSource,
@@ -50,6 +54,17 @@ for (const control of [
 ]) {
   assert.match(pageSource, new RegExp(control), `missing UI control: ${control}`);
 }
+
+assert.match(
+  pageSource,
+  /MAX_COVER_UPLOAD_BYTES\s*=\s*4\s*\*\s*1024\s*\*\s*1024/,
+  "news/events page must guard cover uploads at 4MB before base64 conversion"
+);
+assert.match(
+  trpcRouteSource,
+  /sizeLimit:\s*"8mb"/,
+  "tRPC route must allow base64 cover uploads above Next.js default 1MB body limit"
+);
 
 assert.doesNotMatch(
   pageSource,

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -4,6 +4,16 @@ import { env } from "~/env";
 import { appRouter } from "~/server/api/root";
 import { createTRPCContext } from "~/server/api/trpc";
 
+export const config = {
+  api: {
+    bodyParser: {
+      // Cover uploads travel through tRPC as base64 JSON before the
+      // dashboard server forwards raw bytes to the frontend admin API.
+      sizeLimit: "8mb",
+    },
+  },
+};
+
 // export API handler
 export default createNextApiHandler({
   router: appRouter,

--- a/src/pages/dashboard/news-events/index.tsx
+++ b/src/pages/dashboard/news-events/index.tsx
@@ -24,6 +24,8 @@ type NewsEventFormInput = RouterInputs["newsEvents"]["create"];
 type StatusFilter = "all" | NewsEventItem["status"];
 type TypeFilter = "all" | NewsEventItem["type"];
 
+const MAX_COVER_UPLOAD_BYTES = 4 * 1024 * 1024;
+
 interface FormState {
   id?: string;
   title: string;
@@ -281,6 +283,12 @@ export default function NewsEventsAdminPage() {
 
   const handleCoverUpload = async (file: File | undefined) => {
     if (!file) return;
+
+    if (file.size > MAX_COVER_UPLOAD_BYTES) {
+      toast.error("รูปปกต้องไม่เกิน 4MB");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
 
     try {
       const base64 = await readFileAsBase64(file);

--- a/src/server/services/news-admin-api-client.ts
+++ b/src/server/services/news-admin-api-client.ts
@@ -74,10 +74,20 @@ const newsEventAdminUploadCoverResponseSchema = z.object({
   }),
 });
 
+const MAX_NEWS_EVENT_COVER_BYTES = 4 * 1024 * 1024;
+const MAX_NEWS_EVENT_COVER_BASE64_LENGTH =
+  Math.ceil(MAX_NEWS_EVENT_COVER_BYTES / 3) * 4;
+
 export const uploadNewsEventCoverInputSchema = z.object({
   filename: z.string().min(1).max(180),
   contentType: z.string().startsWith("image/"),
-  base64: z.string().min(1),
+  base64: z
+    .string()
+    .min(1)
+    .max(
+      MAX_NEWS_EVENT_COVER_BASE64_LENGTH,
+      "Cover image must be 4MB or smaller",
+    ),
 });
 
 export type NewsEventAdminItem = z.infer<typeof newsEventAdminItemSchema>;


### PR DESCRIPTION
## Summary
- raise the dashboard tRPC body parser limit to 8mb for base64 JSON cover uploads
- add a 4MB raw image guard in the news/events UI before base64 conversion
- add matching server-side base64 size validation and smoke coverage

## Verification
- npm run test:news-admin-env
- npm run test:news-admin-ui
- npm run test:news-admin-proxy
- npx tsc --noEmit
- npm run lint
- npm run build
- Runtime proof: posted a 1,250,071-byte JSON payload to /api/trpc/newsEvents.uploadCover locally and got 401 UNAUTHORIZED, not 413/body limit

## Notes
- Existing lint warnings remain in unrelated dashboard files.
- Frontend upload API is unchanged; the issue was dashboard tRPC transport overhead.